### PR TITLE
feat(login): correct bear animation

### DIFF
--- a/pages/login/style.css
+++ b/pages/login/style.css
@@ -215,22 +215,21 @@ form button:hover {
 }
 
 /* --- Animation States for Hands --- */
-/* Corrected values for perfect eye coverage */
 .hand-l.hiding {
-  top: 3.8em;
-  left: 10.5em;
-  transform: rotate(-145deg);
+  top: 2.8em;
+  left: 11em;
+  transform: rotate(-150deg);
 }
 .hand-r.hiding {
-  top: 3.8em;
-  right: 10.5em;
-  transform: rotate(145deg);
+  top: 2.8em;
+  right: 11em;
+  transform: rotate(150deg);
 }
-/* Corrected values for peeking */
+/* Values for peeking */
 .hand-r.peeking {
-  top: 5.5em;
-  right: 9.5em;
-  transform: rotate(135deg);
+  top: 4em;
+  right: 10.5em;
+  transform: rotate(140deg);
 }
 
 .paw-l,


### PR DESCRIPTION
The bear on the login page now correctly covers its eyes when the user focuses on the password field and peeks when the 'show password' icon is clicked.

This was achieved by adjusting the CSS properties for the `.hiding` and `.peeking` classes in `pages/login/style.css`.

The changes have been verified using a Playwright script to ensure the animations work as expected.